### PR TITLE
fix: document STP=C boundary invariant in splitDates + regression tests

### DIFF
--- a/R/atoc_export.R
+++ b/R/atoc_export.R
@@ -209,16 +209,30 @@ splitDates <- function(cal) {
   # remove duplicated rows
   cal.new <- cal.new[!duplicated(cal.new), ]
 
-  # modify end and start dates
+  # Trim boundary dates so adjacent segments do not share a day.
+  #
+  # IMPORTANT: only P (permanent) rows are modified here, deliberately.
+  #
+  # When a STP=C row occupies position j-1, its end_date must remain at its
+  # original value so that the comparison below fires correctly:
+  #   start_date[j]  ==  end_date[j-1]  (original C end)  →  TRUE  →  bump
+  #
+  # If we also modified C rows (as master once did), end_date[j-1] would be
+  # decremented at j-1 and the check at j would silently fail, leaving the
+  # following P segment starting on the last day of the cancellation window
+  # instead of the day after.  This produced "ghost" trips that appeared to
+  # run on days they had been STP-cancelled.
   for (j in seq(1, nrow(cal.new))) {
     if (cal.new$STP[j] == "P") {
-      # check if end date need changing
+      # trim end so it does not overlap with the next segment's start
       if (j < nrow(cal.new)) {
         if (cal.new$end_date[j] == cal.new$start_date[j + 1]) {
           cal.new$end_date[j] <- (cal.new$end_date[j] - 1)
         }
       }
-      # check if start date needs changing
+      # push start forward if it sits on the boundary of the previous segment
+      # (works correctly because C rows above are never modified, so
+      # end_date[j-1] still holds the original C DateTo when j-1 is a C row)
       if (j > 1) {
         if (cal.new$start_date[j] == cal.new$end_date[j - 1]) {
           cal.new$start_date[j] <- (cal.new$start_date[j] + 1)

--- a/tests/testthat/test_calendar_split.R
+++ b/tests/testthat/test_calendar_split.R
@@ -1,0 +1,137 @@
+context("STP-C multi-day cancellation calendar boundary")
+
+# Helper to build a minimal schedule data frame accepted by splitDates /
+# makeCalendar.inner.  Column names with spaces must be preserved.
+make_cal <- function(uids, start_dates, end_dates, days, stps,
+                     rowids = NULL) {
+  n <- length(uids)
+  if (is.null(rowids)) rowids <- rep(1L, n)
+  data.frame(
+    UID                  = uids,
+    start_date           = as.Date(start_dates),
+    end_date             = as.Date(end_dates),
+    Days                 = days,
+    STP                  = stps,
+    rowID                = as.integer(rowids),
+    Headcode             = rep("", n),
+    "ATOC Code"          = rep("ZA", n),
+    "Retail Train ID"    = rep("", n),
+    "Train Status"       = rep("P", n),
+    duration             = as.numeric(
+      as.Date(end_dates) - as.Date(start_dates) + 1
+    ),
+    stringsAsFactors = FALSE,
+    check.names      = FALSE
+  )
+}
+
+# ── splitDates: multi-day STP=C (same day pattern as P) ───────────────────────
+#
+# Regression test for the "ghost service" bug:
+#   A permanent Mon–Fri service with a 3-day STP=C cancellation (Wed–Fri
+#   24–26 Jun 2026) was producing a post-cancellation P segment that started
+#   on 2026-06-26 — the last day of the cancellation — instead of
+#   2026-06-27 (the day after).
+#
+# Root cause: the date-trimming loop was modifying C rows as well as P rows.
+# When the C row at position j-1 had its end_date decremented, the start-date
+# check for the P row at position j would compare against the already-modified
+# value and silently not fire, leaving the P segment one day too early.
+#
+# Fix: the loop now only processes P rows (guarded by `if (STP == "P")`), so
+# the C row's end_date stays at its original value and the comparison at j
+# correctly increments the P start_date.
+
+test_that("P segment after multi-day STP=C starts the day AFTER the C ends", {
+  cal <- make_cal(
+    uids        = c("TEST01", "TEST01"),
+    start_dates = c("2026-05-18", "2026-06-24"),
+    end_dates   = c("2026-09-18", "2026-06-26"),
+    days        = c("1111100",   "1111100"),   # same day pattern
+    stps        = c("P",         "C")
+  )
+
+  result <- UK2GTFS:::splitDates(cal)
+
+  expect_true(is.data.frame(result),
+              info = "splitDates should return a data.frame")
+
+  # The post-cancellation segment
+  post <- result[result$start_date >= as.Date("2026-06-26"), ]
+  expect_true(nrow(post) > 0,
+              info = "should have at least one segment after the cancellation")
+
+  earliest <- min(post$start_date)
+  expect_gt(
+    as.numeric(earliest),
+    as.numeric(as.Date("2026-06-26")),
+    label = paste0(
+      "Post-cancellation P segment must start AFTER 2026-06-26 ",
+      "(the STP=C DateTo); got ", earliest
+    )
+  )
+})
+
+# ── splitDates: multi-day STP=C with different day pattern ────────────────────
+#
+# Mirrors the actual L80073 scenario: permanent Mon–Fri service, cancelled
+# only on Wed–Fri (Days="0011100") for 24–26 Jun.  The "split by day pattern"
+# path in makeCalendar.inner groups P + C together because all C rows are
+# always included regardless of day pattern.
+
+test_that("P segment after multi-day STP=C (different day pattern) starts after C ends", {
+  cal <- make_cal(
+    uids        = c("L80073", "L80073"),
+    start_dates = c("2026-05-18", "2026-06-24"),
+    end_dates   = c("2026-09-18", "2026-06-26"),
+    days        = c("1111100",   "0011100"),   # different day patterns
+    stps        = c("P",         "C")
+  )
+
+  result <- UK2GTFS:::splitDates(cal)
+
+  expect_true(is.data.frame(result))
+
+  post <- result[result$start_date >= as.Date("2026-06-26"), ]
+  expect_true(nrow(post) > 0)
+
+  earliest <- min(post$start_date)
+  expect_gt(
+    as.numeric(earliest),
+    as.numeric(as.Date("2026-06-26")),
+    label = paste0(
+      "Post-cancellation P segment must start AFTER the STP=C DateTo; got ",
+      earliest
+    )
+  )
+})
+
+# ── makeCalendar.inner: single-day STP=C goes to calendar_dates ───────────────
+#
+# The simple path (exactly one P + one 1-day C, same STP group) should return
+# the P in calendar and the C in calendar_dates as a GTFS exception, not
+# attempt date-splitting.
+
+test_that("single-day STP=C with one P produces a calendar_dates entry", {
+  cal <- make_cal(
+    uids        = c("TEST02", "TEST02"),
+    start_dates = c("2026-01-01", "2026-06-26"),
+    end_dates   = c("2026-12-31", "2026-06-26"),
+    days        = c("1111100",   "1111100"),
+    stps        = c("P",         "C")
+  )
+
+  result <- UK2GTFS:::makeCalendar.inner(cal)
+
+  expect_true(is.list(result), info = "makeCalendar.inner should return a list")
+
+  cal_out       <- result[[1]]
+  cal_dates_out <- result[[2]]
+
+  expect_equal(nrow(cal_out), 1L,
+               info = "P schedule should produce a single calendar row")
+  expect_true(is.data.frame(cal_dates_out),
+              info = "single-day C should be returned as a calendar_dates data.frame")
+  expect_equal(cal_dates_out$start_date[1], as.Date("2026-06-26"),
+               info = "calendar_dates entry should be on the cancelled date")
+})


### PR DESCRIPTION
## Summary

This PR documents and protects the existing fix for a **ghost-service bug** where a post-cancellation permanent schedule segment began running on the last day of its STP=C cancellation window instead of the day after.

- Adds a detailed explanatory comment to the `splitDates` P-only loop explaining *why* it must not modify C rows, preventing the guard from being accidentally removed in future refactors
- Adds `tests/testthat/test_calendar_split.R` with three regression tests covering the broken scenario

## Background: the bug

A permanent Mon–Fri service (e.g. UID `L80073`) with a multi-day STP=C cancellation (e.g. Wed–Fri 24–26 Jun) was producing a post-cancellation GTFS calendar segment that started on **2026-06-26** (the last cancelled day) instead of **2026-06-27** (the day after the cancellation ended).

This caused `L80073` to appear in OpenTripPlanner as running on the day it was supposed to be replaced by the new service `Q12453`.

### Root cause

The date-trimming loop inside `splitDates` was (on `master`) applied to **all** rows:

```r
# master — buggy
for (j in seq(1, nrow(cal.new))) {
  # no STP guard — modifies C rows too
  if (j < nrow(cal.new)) {
    if (cal.new$end_date[j] == cal.new$start_date[j + 1])
      cal.new$end_date[j] <- cal.new$end_date[j] - 1   # decrements C end_date
  }
  if (j > 1) {
    if (cal.new$start_date[j] == cal.new$end_date[j - 1])
      # end_date[j-1] was already decremented — check never fires!
      cal.new$start_date[j] <- cal.new$start_date[j] + 1
  }
}
```

When the loop reached the C row at position `j-1`, it decremented `end_date[j-1]`. Then at position `j` (the P row), the comparison `start_date[j] == end_date[j-1]` used the **already-modified** value, so the equality check did not fire and the P start was never bumped forward.

### The fix (already present at `4a4cc90`)

The loop is guarded by `if (cal.new$STP[j] == "P")`. C rows are skipped entirely, so `end_date[j-1]` retains its original value when the P row at `j` does its check — and the start correctly advances.

## Deployment note

The Docker images (`zipabout/base-uk2gtfs` and `events-platform-ingestion-networkrailciftogtfs`) were built **before** the `4a4cc90` fix landed in the production branch. After merging this PR the Docker base image must be rebuilt and pushed, then the `NetworkRailCIFToGTFS` image rebuilt on top of it, for the corrected calendar logic to take effect.

## Changes

| File | Change |
|---|---|
| `R/atoc_export.R` | Added 15-line explanatory comment to the `splitDates` P-only loop |
| `tests/testthat/test_calendar_split.R` | New file — 3 regression tests for the STP=C calendar boundary |

## Tests

- `P segment after multi-day STP=C starts the day AFTER the C ends` — same day pattern
- `P segment after multi-day STP=C (different day pattern) starts after C ends` — mirrors the real L80073/Q12453 scenario
- `single-day STP=C with one P produces a calendar_dates entry` — verifies the existing simple path still works