### PR TITLE
feat: per-slot overlay detection in splitDates (overlay fix from master, P guard kept)

### DIFF
--- a/R/atoc_export.R
+++ b/R/atoc_export.R
@@ -155,32 +155,38 @@ splitDates <- function(cal) {
     by = c( "start_date", "end_date" )
   )
 
-  if ("P" %in% cal$STP) {
-    match <- "P"
-  } else {
-    match <- cal$STP[cal$STP != "C"]
-    match <- match[1]
-  }
-
   # fill in the original missing schedule
+  # For each gap slot, check whether an overlay (STP=O) covers that date range;
+  # if so, use the O timetable to fill it rather than the permanent (P) one.
+  # This is the correct STP priority: O overrides P for the period it covers.
   for (j in seq(1, nrow(cal.new))) {
     if (is.na(cal.new$UID[j])) {
       st_tmp <- cal.new$start_date[j]
       ed_tmp <- cal.new$end_date[j]
-      new.UID <- cal$UID[cal$STP == match & cal$start_date <= st_tmp &
+      overlay_exists <- any(cal$STP == "O" &
+        cal$start_date <= st_tmp & cal$end_date >= ed_tmp)
+      if (overlay_exists) {
+        match_stp <- "O"
+      } else if ("P" %in% cal$STP) {
+        match_stp <- "P"
+      } else {
+        match_stp <- cal$STP[cal$STP != "C"]
+        match_stp <- match_stp[1]
+      }
+      new.UID <- cal$UID[cal$STP == match_stp & cal$start_date <= st_tmp &
         cal$end_date >= ed_tmp]
-      new.Days <- cal$Days[cal$STP == match & cal$start_date <= st_tmp &
+      new.Days <- cal$Days[cal$STP == match_stp & cal$start_date <= st_tmp &
         cal$end_date >= ed_tmp]
-      new.roWID <- cal$rowID[cal$STP == match & cal$start_date <= st_tmp &
+      new.roWID <- cal$rowID[cal$STP == match_stp & cal$start_date <= st_tmp &
         cal$end_date >= ed_tmp]
-      new.ATOC <- cal$`ATOC Code`[cal$STP == match & cal$start_date <= st_tmp &
+      new.ATOC <- cal$`ATOC Code`[cal$STP == match_stp & cal$start_date <= st_tmp &
         cal$end_date >= ed_tmp]
-      new.Retail <- cal$`Retail Train ID`[cal$STP == match &
+      new.Retail <- cal$`Retail Train ID`[cal$STP == match_stp &
         cal$start_date <= st_tmp &
         cal$end_date >= ed_tmp]
-      new.head <- cal$Headcode[cal$STP == match & cal$start_date <= st_tmp &
+      new.head <- cal$Headcode[cal$STP == match_stp & cal$start_date <= st_tmp &
         cal$end_date >= ed_tmp]
-      new.Status <- cal$`Train Status`[cal$STP == match &
+      new.Status <- cal$`Train Status`[cal$STP == match_stp &
         cal$start_date <= st_tmp &
         cal$end_date >= ed_tmp]
       if (length(new.UID) == 1) {
@@ -191,7 +197,7 @@ splitDates <- function(cal) {
         cal.new$`Retail Train ID`[j] <- new.Retail
         cal.new$`Train Status`[j] <- new.Status
         cal.new$Headcode[j] <- new.head
-        cal.new$STP[j] <- match
+        cal.new$STP[j] <- match_stp
       } else if (length(new.UID) > 1) {
         message("Going From")
         print(cal)


### PR DESCRIPTION
## What this does

This PR brings `master` and `production` into sync by applying the **overlay-aware gap-fill improvement** that existed on `master` (from `4a4cc90`) while **keeping the STP=P boundary guard** that was only on `production`.

## Background

In May 2025 commit `4a4cc90` was written with two changes bundled together:

**Part A — overlay gap-fill (good):** When `splitDates` carves a permanent schedule around a date range and needs to fill the resulting gap slots, it should prefer an Overlay (O) timetable when one covers that slot, rather than always defaulting to Permanent (P). Without this, services with a modified timetable during a specific period (bank holidays, engineering works) get the wrong trip times.

**Part B — removal of P guard (regression):** The boundary-trimming loop that nudges adjacent date boundaries apart was also changed to run on *all* rows including C (cancellation) rows. This caused C record end-dates to be decremented, breaking the following P row's start-date check so it silently didn't fire — leaving the post-cancellation P segment starting on the last day of the cancellation window instead of the day after. This is the ghost-service bug.

`4a4cc90` was merged to `master` via PR #5. The two follow-on commits (`9d8d3f4`, `67239df`) tried to fix the regression further, and all three were then reverted on `production` (`6629913`). The revert correctly removed Part B but also threw away Part A. The revert was never merged back to `master`, leaving the two branches out of sync.

## What this PR does

- **Applies Part A only** — per-slot `overlay_exists` check in the gap-fill loop
- **Leaves the boundary loop untouched** — the `if (cal.new$STP[j] == "P")` guard is preserved exactly as it is on `production`

## After merging this PR

Open a follow-up PR from `production` → `master` to bring master in line. At that point both branches are identical and the history is clean.