### PR TITLE
sync: bring master in line with production

### DIFF
--- a/R/atoc_export.R
+++ b/R/atoc_export.R
@@ -492,8 +492,8 @@ makeCalendar.inner <- function(calendar.sub) { # i, UIDs, calendar){
       ))
     } else {
       # Check if there are any overlay schedules that need to be processed with permanent schedules
-      has_overlays <- any(typ.all == "O")
-      has_permanent <- any(typ.all == "P")
+      has_overlays <- sum(typ.all == "O") > 0
+      has_permanent <- sum(typ.all == "P") > 0
       
       # Process together if we have both overlays and permanent schedules
       if (has_overlays && has_permanent) {

--- a/R/atoc_export.R
+++ b/R/atoc_export.R
@@ -491,8 +491,16 @@ makeCalendar.inner <- function(calendar.sub) { # i, UIDs, calendar){
         calendar.sub[calendar.sub$STP != "P", ]
       ))
     } else {
-      # check for identical day pattern
-      if (length(unique(calendar.sub$Days)) == 1 &
+      # Check if there are any overlay schedules that need to be processed with permanent schedules
+      has_overlays <- any(typ.all == "O")
+      has_permanent <- any(typ.all == "P")
+      
+      # Process together if we have both overlays and permanent schedules
+      if (has_overlays && has_permanent) {
+        # Process all schedules together to handle the overlays properly
+        calendar.new <- splitDates(calendar.sub)
+        return(list(calendar.new, NA))
+      } else if (length(unique(calendar.sub$Days)) == 1 &
         sum(typ.all == "P") == 1) {
         calendar.new <- splitDates(calendar.sub)
         #calendar.new <- UK2GTFS:::splitDates(calendar.sub)

--- a/R/atoc_export.R
+++ b/R/atoc_export.R
@@ -155,32 +155,38 @@ splitDates <- function(cal) {
     by = c( "start_date", "end_date" )
   )
 
-  if ("P" %in% cal$STP) {
-    match <- "P"
-  } else {
-    match <- cal$STP[cal$STP != "C"]
-    match <- match[1]
-  }
-
   # fill in the original missing schedule
+  # For each gap slot, check whether an overlay (STP=O) covers that date range;
+  # if so, use the O timetable to fill it rather than the permanent (P) one.
+  # This is the correct STP priority: O overrides P for the period it covers.
   for (j in seq(1, nrow(cal.new))) {
     if (is.na(cal.new$UID[j])) {
       st_tmp <- cal.new$start_date[j]
       ed_tmp <- cal.new$end_date[j]
-      new.UID <- cal$UID[cal$STP == match & cal$start_date <= st_tmp &
+      overlay_exists <- any(cal$STP == "O" &
+        cal$start_date <= st_tmp & cal$end_date >= ed_tmp)
+      if (overlay_exists) {
+        match_stp <- "O"
+      } else if ("P" %in% cal$STP) {
+        match_stp <- "P"
+      } else {
+        match_stp <- cal$STP[cal$STP != "C"]
+        match_stp <- match_stp[1]
+      }
+      new.UID <- cal$UID[cal$STP == match_stp & cal$start_date <= st_tmp &
         cal$end_date >= ed_tmp]
-      new.Days <- cal$Days[cal$STP == match & cal$start_date <= st_tmp &
+      new.Days <- cal$Days[cal$STP == match_stp & cal$start_date <= st_tmp &
         cal$end_date >= ed_tmp]
-      new.roWID <- cal$rowID[cal$STP == match & cal$start_date <= st_tmp &
+      new.roWID <- cal$rowID[cal$STP == match_stp & cal$start_date <= st_tmp &
         cal$end_date >= ed_tmp]
-      new.ATOC <- cal$`ATOC Code`[cal$STP == match & cal$start_date <= st_tmp &
+      new.ATOC <- cal$`ATOC Code`[cal$STP == match_stp & cal$start_date <= st_tmp &
         cal$end_date >= ed_tmp]
-      new.Retail <- cal$`Retail Train ID`[cal$STP == match &
+      new.Retail <- cal$`Retail Train ID`[cal$STP == match_stp &
         cal$start_date <= st_tmp &
         cal$end_date >= ed_tmp]
-      new.head <- cal$Headcode[cal$STP == match & cal$start_date <= st_tmp &
+      new.head <- cal$Headcode[cal$STP == match_stp & cal$start_date <= st_tmp &
         cal$end_date >= ed_tmp]
-      new.Status <- cal$`Train Status`[cal$STP == match &
+      new.Status <- cal$`Train Status`[cal$STP == match_stp &
         cal$start_date <= st_tmp &
         cal$end_date >= ed_tmp]
       if (length(new.UID) == 1) {
@@ -191,7 +197,7 @@ splitDates <- function(cal) {
         cal.new$`Retail Train ID`[j] <- new.Retail
         cal.new$`Train Status`[j] <- new.Status
         cal.new$Headcode[j] <- new.head
-        cal.new$STP[j] <- match
+        cal.new$STP[j] <- match_stp
       } else if (length(new.UID) > 1) {
         message("Going From")
         print(cal)


### PR DESCRIPTION
## What this does

Syncs `master` with `production` after PR #7 merges.

**Merge PR #7 first, then merge this one.**

## What changes

Replaces the `splitDates` changes that were on `master` (from `4a4cc90` via PR #5) with the correct combined version on `production`:

| | master (before) | production (after PR #7) |
|---|---|---|
| Gap-fill logic | Per-slot overlay detection | Per-slot overlay detection ✅ |
| Boundary trimming | No P guard — runs on all rows including C ❌ | P guard kept — only runs on P rows ✅ |

The net effect: `master` had the overlay improvement but also had the ghost-service regression (P segment after a cancellation starting one day too early). After this sync both branches have the improvement without the regression.