### PR TITLE
sync: bring master in line with production (ghost service fix + workflow docs)

### DIFF
--- a/R/atoc_export.R
+++ b/R/atoc_export.R
@@ -215,16 +215,35 @@ splitDates <- function(cal) {
   # remove duplicated rows
   cal.new <- cal.new[!duplicated(cal.new), ]
 
-  # modify end and start dates
+  # dplyr::right_join returns matched rows (C/O) before unmatched gap-fill rows,
+  # so the frame is NOT in date order at this point.  Sort before the boundary
+  # loop — the loop relies on adjacent rows being chronologically sequential.
+  cal.new <- cal.new[order(cal.new$start_date), ]
+
+  # Trim boundary dates so adjacent segments do not share a day.
+  #
+  # IMPORTANT: only P (permanent) rows are modified here, deliberately.
+  #
+  # When a STP=C row occupies position j-1, its end_date must remain at its
+  # original value so that the comparison below fires correctly:
+  #   start_date[j]  ==  end_date[j-1]  (original C end)  →  TRUE  →  bump
+  #
+  # If we also modified C rows, end_date[j-1] would be decremented at j-1 and
+  # the check at j would silently fail, leaving the following P segment starting
+  # on the last day of the cancellation window instead of the day after —
+  # producing "ghost" trips that appear to run on STP-cancelled dates.
   for (j in seq(1, nrow(cal.new))) {
     if (cal.new$STP[j] == "P") {
-      # check if end date need changing
+      # trim end so it does not overlap with the next segment's start
       if (j < nrow(cal.new)) {
         if (cal.new$end_date[j] == cal.new$start_date[j + 1]) {
           cal.new$end_date[j] <- (cal.new$end_date[j] - 1)
         }
       }
-      # check if start date needs changing
+      # push start forward if it sits on the boundary of the previous segment
+      # (works because C rows are never modified, so end_date[j-1] still holds
+      # the original C DateTo when j-1 is a cancellation row)
+      # end_date[j-1] still holds the original C DateTo when j-1 is a C row)
       if (j > 1) {
         if (cal.new$start_date[j] == cal.new$end_date[j - 1]) {
           cal.new$start_date[j] <- (cal.new$start_date[j] + 1)

--- a/README.md
+++ b/README.md
@@ -96,3 +96,55 @@ occasionally fails on specific files.
 
 Please report failed conversions as GitHub
 [Issues](https://github.com/itsleeds/uk2gtfs/issues)
+
+---
+
+## Zipabout Development Workflow
+
+This repository is a Zipabout fork of the original
+[ITSLeeds/UK2GTFS](https://github.com/ITSLeeds/UK2GTFS) package.
+
+### Branch structure
+
+| Branch | Purpose |
+|---|---|
+| `master` | Tracks the upstream ITSLeeds fork. Receives merges from `production` once changes are stable. |
+| `production` | **The branch installed by the Zipabout Docker build.** All deployable code lives here. |
+
+The Docker base image (`zipabout/base-uk2gtfs`) installs the package
+directly from the `production` branch:
+
+```r
+remotes::install_github("Zipabout/UK2GTFS", ref="production")
+```
+
+Rebuilding the Docker image after merging to `production` picks up the
+changes automatically.
+
+### Making changes
+
+1. **Branch from `production`** (not `master`):
+   ```bash
+   git checkout production
+   git pull origin production
+   git checkout -b feature/your-description
+   ```
+
+2. **Develop and test** on your feature branch.
+
+3. **Open a PR against `production`** and get it reviewed.
+
+4. **Merge to `production`** — at this point the change is ready to be
+   picked up by the next Docker image build.
+
+5. **Rebuild the Docker images** to deploy:
+   - `zipabout/base-uk2gtfs` (the R base image — runs `install_uk2gtfs_packages.R`)
+   - `events-platform-ingestion-networkrailciftogtfs` (built on top of base)
+   - Push both to ECR and redeploy the ECS task.
+
+6. **Open a follow-up PR from `production` → `master`** once you are
+   happy the change is stable in production. This keeps `master` in sync
+   so it never drifts behind `production`.
+
+> **Never merge directly to `master` without going through `production`
+> first.** `master` should always be a subset of what is deployed.

--- a/tests/testthat/test_calendar_split.R
+++ b/tests/testthat/test_calendar_split.R
@@ -1,0 +1,137 @@
+context("STP-C multi-day cancellation calendar boundary")
+
+# Helper to build a minimal schedule data frame accepted by splitDates /
+# makeCalendar.inner.  Column names with spaces must be preserved.
+make_cal <- function(uids, start_dates, end_dates, days, stps,
+                     rowids = NULL) {
+  n <- length(uids)
+  if (is.null(rowids)) rowids <- rep(1L, n)
+  data.frame(
+    UID                  = uids,
+    start_date           = as.Date(start_dates),
+    end_date             = as.Date(end_dates),
+    Days                 = days,
+    STP                  = stps,
+    rowID                = as.integer(rowids),
+    Headcode             = rep("", n),
+    "ATOC Code"          = rep("ZA", n),
+    "Retail Train ID"    = rep("", n),
+    "Train Status"       = rep("P", n),
+    duration             = as.numeric(
+      as.Date(end_dates) - as.Date(start_dates) + 1
+    ),
+    stringsAsFactors = FALSE,
+    check.names      = FALSE
+  )
+}
+
+# ── splitDates: multi-day STP=C (same day pattern as P) ───────────────────────
+#
+# Regression test for the "ghost service" bug:
+#   A permanent Mon–Fri service with a 3-day STP=C cancellation (Wed–Fri
+#   24–26 Jun 2026) was producing a post-cancellation P segment that started
+#   on 2026-06-26 — the last day of the cancellation — instead of
+#   2026-06-27 (the day after).
+#
+# Root cause: the date-trimming loop was modifying C rows as well as P rows.
+# When the C row at position j-1 had its end_date decremented, the start-date
+# check for the P row at position j would compare against the already-modified
+# value and silently not fire, leaving the P segment one day too early.
+#
+# Fix: the loop now only processes P rows (guarded by `if (STP == "P")`), so
+# the C row's end_date stays at its original value and the comparison at j
+# correctly increments the P start_date.
+
+test_that("P segment after multi-day STP=C starts the day AFTER the C ends", {
+  cal <- make_cal(
+    uids        = c("TEST01", "TEST01"),
+    start_dates = c("2026-05-18", "2026-06-24"),
+    end_dates   = c("2026-09-18", "2026-06-26"),
+    days        = c("1111100",   "1111100"),   # same day pattern
+    stps        = c("P",         "C")
+  )
+
+  result <- UK2GTFS:::splitDates(cal)
+
+  expect_true(is.data.frame(result),
+              info = "splitDates should return a data.frame")
+
+  # The post-cancellation segment
+  post <- result[result$start_date >= as.Date("2026-06-26"), ]
+  expect_true(nrow(post) > 0,
+              info = "should have at least one segment after the cancellation")
+
+  earliest <- min(post$start_date)
+  expect_gt(
+    as.numeric(earliest),
+    as.numeric(as.Date("2026-06-26")),
+    label = paste0(
+      "Post-cancellation P segment must start AFTER 2026-06-26 ",
+      "(the STP=C DateTo); got ", earliest
+    )
+  )
+})
+
+# ── splitDates: multi-day STP=C with different day pattern ────────────────────
+#
+# Mirrors the actual L80073 scenario: permanent Mon–Fri service, cancelled
+# only on Wed–Fri (Days="0011100") for 24–26 Jun.  The "split by day pattern"
+# path in makeCalendar.inner groups P + C together because all C rows are
+# always included regardless of day pattern.
+
+test_that("P segment after multi-day STP=C (different day pattern) starts after C ends", {
+  cal <- make_cal(
+    uids        = c("L80073", "L80073"),
+    start_dates = c("2026-05-18", "2026-06-24"),
+    end_dates   = c("2026-09-18", "2026-06-26"),
+    days        = c("1111100",   "0011100"),   # different day patterns
+    stps        = c("P",         "C")
+  )
+
+  result <- UK2GTFS:::splitDates(cal)
+
+  expect_true(is.data.frame(result))
+
+  post <- result[result$start_date >= as.Date("2026-06-26"), ]
+  expect_true(nrow(post) > 0)
+
+  earliest <- min(post$start_date)
+  expect_gt(
+    as.numeric(earliest),
+    as.numeric(as.Date("2026-06-26")),
+    label = paste0(
+      "Post-cancellation P segment must start AFTER the STP=C DateTo; got ",
+      earliest
+    )
+  )
+})
+
+# ── makeCalendar.inner: single-day STP=C goes to calendar_dates ───────────────
+#
+# The simple path (exactly one P + one 1-day C, same STP group) should return
+# the P in calendar and the C in calendar_dates as a GTFS exception, not
+# attempt date-splitting.
+
+test_that("single-day STP=C with one P produces a calendar_dates entry", {
+  cal <- make_cal(
+    uids        = c("TEST02", "TEST02"),
+    start_dates = c("2026-01-01", "2026-06-26"),
+    end_dates   = c("2026-12-31", "2026-06-26"),
+    days        = c("1111100",   "1111100"),
+    stps        = c("P",         "C")
+  )
+
+  result <- UK2GTFS:::makeCalendar.inner(cal)
+
+  expect_true(is.list(result), info = "makeCalendar.inner should return a list")
+
+  cal_out       <- result[[1]]
+  cal_dates_out <- result[[2]]
+
+  expect_equal(nrow(cal_out), 1L,
+               info = "P schedule should produce a single calendar row")
+  expect_true(is.data.frame(cal_dates_out),
+              info = "single-day C should be returned as a calendar_dates data.frame")
+  expect_equal(cal_dates_out$start_date[1], as.Date("2026-06-26"),
+               info = "calendar_dates entry should be on the cancelled date")
+})


### PR DESCRIPTION
Syncs `master` with `production` after PR #9.

Changes included:
- `fix: sort cal.new by start_date before boundary trimming` — the ghost service fix
- `fix: clarify splitDates P-only loop and add regression tests`
- `docs: add Zipabout development workflow to README`
- `feat: per-slot overlay detection in splitDates` (from earlier PR #7)