### PR TITLE
chore: sync production → master (bus route_type fixes)

### DIFF
--- a/R/atoc_main.R
+++ b/R/atoc_main.R
@@ -112,9 +112,12 @@ schedule2routes <- function(stop_times, stops, schedule, silent = TRUE, ncores =
 
   # Apply route_type to trips BEFORE grouping so it survives dplyr::summarise.
   # 110 = Rail Replacement Bus (extended GTFS)
+  # All bus services in a CIF feed are rail-related (replacement or rail-operated),
+  # so Status='B' (permanent bus) maps to 110 (Rail Replacement Bus), not 3 (Bus).
+  # Status='5' (STP bus) already maps to 110.
   train_status <- data.frame(
     train_status = c("B", "F", "P", "S", "T", "1", "2", "3", "4", "5"),
-    route_type   = c(  3, NA,  2,  4, NA,  2, NA, NA,  4, 110),
+    route_type   = c(110, NA,  2,  4, NA,  2, NA, NA,  4, 110),
     stringsAsFactors = FALSE
   )
   trips$`Train Status` <- as.character(trips$`Train Status`)

--- a/R/atoc_main.R
+++ b/R/atoc_main.R
@@ -111,13 +111,15 @@ schedule2routes <- function(stop_times, stops, schedule, silent = TRUE, ncores =
   }
 
   # Apply route_type to trips BEFORE grouping so it survives dplyr::summarise.
-  # 110 = Rail Replacement Bus (extended GTFS)
-  # All bus services in a CIF feed are rail-related (replacement or rail-operated),
-  # so Status='B' (permanent bus) maps to 110 (Rail Replacement Bus), not 3 (Bus).
-  # Status='5' (STP bus) already maps to 110.
+  # 110 = Rail Replacement Bus (extended GTFS); OTP routes type=110 as RAIL mode,
+  # so {mode: RAIL} queries automatically include replacement buses without returning
+  # regular (type=3) bus services.
+  #
+  # Status='B' = permanent scheduled bus (Category='BS') → type 3 (Bus)
+  # Status='5' = STP bus (Category='BR')                 → type 110 (Rail Replacement)
   train_status <- data.frame(
     train_status = c("B", "F", "P", "S", "T", "1", "2", "3", "4", "5"),
-    route_type   = c(110, NA,  2,  4, NA,  2, NA, NA,  4, 110),
+    route_type   = c(  3, NA,  2,  4, NA,  2, NA, NA,  4, 110),
     stringsAsFactors = FALSE
   )
   trips$`Train Status` <- as.character(trips$`Train Status`)
@@ -128,6 +130,13 @@ schedule2routes <- function(stop_times, stops, schedule, silent = TRUE, ncores =
   # should be route_type 1 (Subway/Metro), not 2 (Rail).
   # This supersedes the previous agency_id == "LT" check which only caught London Underground.
   trips$route_type[trips$`Train Category` %in% c("EL", "OL") & !is.na(trips$route_type) & trips$route_type == 2] <- 1
+
+  # Rail Replacement Bus fix: Category='BR' (Bus, Rail Replacement) should always be
+  # route_type 110, regardless of Train Status. Status='B' maps to 3 above, but any
+  # service explicitly Category='BR' in the CIF is a rail replacement bus.
+  # Status='5' Cat='BR' already gets 110 via the lookup; this catches Status='B' Cat='BR'
+  # (permanent-schedule replacements like long-running engineering works).
+  trips$route_type[trips$`Train Category` == "BR" & !is.na(trips$route_type)] <- 110
 
   # Group by route_type (not Train Status) so the column survives summarise
   routes <- trips


### PR DESCRIPTION
Brings master up to date with production after today's bus classification fixes.

## Commits
- `0a21271` fix: map all CIF bus services (Status='B') to route_type=110 *(intermediate — superseded)*
- `c01fa19` fix: nuanced bus route_type — BS=3 (scheduled bus), BR=110 (rail replacement)

## Summary
CIF `Category='BS'` (permanent scheduled bus) → `route_type=3`
CIF `Category='BR'` (rail replacement bus) → `route_type=110`

This respects the CIF's own intent. OTP 2.x maps `route_type=110` to `RAIL` mode internally, so `{mode: RAIL}` queries include rail replacement buses without pulling in regular buses.

Deployed as image `1.0.11` on 2026-06-26.